### PR TITLE
Add support for parsing new style jdk9 and later version numbers

### DIFF
--- a/jetty-test-helper/src/main/java/org/eclipse/jetty/toolchain/test/JDK.java
+++ b/jetty-test-helper/src/main/java/org/eclipse/jetty/toolchain/test/JDK.java
@@ -40,9 +40,9 @@ public class JDK
      */
     public static final boolean IS_8 = isJavaVersionAtLeast(1,8);
     /**
-     * True if JDK is 1.9 (or newer) 
+     * True if JDK is 9.0 (or newer)
      */
-    public static final boolean IS_9 = isJavaVersionAtLeast(1,9);
+    public static final boolean IS_9 = isJavaVersionAtLeast(9,0);
 
     private static boolean isJavaVersionAtLeast(int maj, int min)
     {
@@ -52,13 +52,13 @@ public class JDK
             System.err.println("## ERROR: System.getProperty('java.version') == null !?");
             return false;
         }
-        String vparts[] = jver.split("\\.");
+        String vparts[] = jver.split("[-.]");
         if (vparts.length < 2)
         {
             System.err.println("## ERROR: Invalid java version format '" + jver + "'");
             return false;
         }
-        return (toInt(vparts[0]) >= maj && toInt(vparts[1]) >= min);
+        return toInt(vparts[0]) > maj || (toInt(vparts[0]) == maj && toInt(vparts[1]) >= min);
     }
 
     private static int toInt(String val)

--- a/jetty-test-helper/src/test/java/org/eclipse/jetty/toolchain/test/JDKTest.java
+++ b/jetty-test-helper/src/test/java/org/eclipse/jetty/toolchain/test/JDKTest.java
@@ -67,5 +67,14 @@ public class JDKTest
             assertThat("JVM(" + ver + ") / JDK.IS_8",JDK.IS_8,is(true));
             assertThat("JVM(" + ver + ") / JDK.IS_9",JDK.IS_9,is(false));
         }
+        else if (ver.startsWith("9"))
+        {
+            System.err.println("Testing JDK.IS_9 - " + ver);
+            assertThat("JVM(" + ver + ") / JDK.IS_5",JDK.IS_5,is(true));
+            assertThat("JVM(" + ver + ") / JDK.IS_6",JDK.IS_6,is(true));
+            assertThat("JVM(" + ver + ") / JDK.IS_7",JDK.IS_7,is(true));
+            assertThat("JVM(" + ver + ") / JDK.IS_8",JDK.IS_8,is(true));
+            assertThat("JVM(" + ver + ") / JDK.IS_9",JDK.IS_9,is(true));
+        }
     }
 }


### PR DESCRIPTION
See: http://openjdk.java.net/jeps/223
The java.version of jdk9 pre-releases no longer start with 1.9 but with 9