### PR TITLE
Clear supplemental groups when calling setgid

### DIFF
--- a/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUID.java
+++ b/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUID.java
@@ -45,7 +45,7 @@ public class SetUID
 
     public static native int setgid(int gid);
 
-    public static native int cleargroups();
+    public static native int setgroups(int[] gids);
 
     public static native Passwd getpwnam(String name) throws SecurityException;
 

--- a/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUID.java
+++ b/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUID.java
@@ -45,6 +45,8 @@ public class SetUID
 
     public static native int setgid(int gid);
 
+    public static native int cleargroups();
+
     public static native Passwd getpwnam(String name) throws SecurityException;
 
     public static native Passwd getpwuid(int uid) throws SecurityException;

--- a/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDListener.java
+++ b/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDListener.java
@@ -126,6 +126,8 @@ public class SetUIDListener implements LifeCycle.Listener
     {
         if (_gid != 0)
         {
+            LOG.info("Clearing supplemental groups");
+            SetUID.cleargroups();
             LOG.info("Setting GID=" + _gid);
             SetUID.setgid(_gid);
         }

--- a/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDListener.java
+++ b/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDListener.java
@@ -127,7 +127,7 @@ public class SetUIDListener implements LifeCycle.Listener
         if (_gid != 0)
         {
             LOG.info("Clearing supplemental groups");
-            SetUID.cleargroups();
+            SetUID.setgroups(new int[0]);
             LOG.info("Setting GID=" + _gid);
             SetUID.setgid(_gid);
         }

--- a/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDServer.java
+++ b/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDServer.java
@@ -138,6 +138,8 @@ public class SetUIDServer extends Server
             super.doStart();
             if (_gid != 0)
             {
+                LOG.info("Clearing supplemental groups");
+                SetUID.cleargroups();
                 LOG.info("Setting GID=" + _gid);
                 SetUID.setgid(_gid);
             }
@@ -160,6 +162,8 @@ public class SetUIDServer extends Server
             
             if (_gid != 0)
             {
+                LOG.info("Clearing supplemental groups");
+                SetUID.cleargroups();
                 LOG.info("Setting GID=" + _gid);
                 SetUID.setgid(_gid);
             }

--- a/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDServer.java
+++ b/jetty-setuid/jetty-setuid-java/src/main/java/org/eclipse/jetty/setuid/SetUIDServer.java
@@ -139,7 +139,7 @@ public class SetUIDServer extends Server
             if (_gid != 0)
             {
                 LOG.info("Clearing supplemental groups");
-                SetUID.cleargroups();
+                SetUID.setgroups(new int[0]);
                 LOG.info("Setting GID=" + _gid);
                 SetUID.setgid(_gid);
             }
@@ -163,7 +163,7 @@ public class SetUIDServer extends Server
             if (_gid != 0)
             {
                 LOG.info("Clearing supplemental groups");
-                SetUID.cleargroups();
+                SetUID.setgroups(new int[0]);
                 LOG.info("Setting GID=" + _gid);
                 SetUID.setgid(_gid);
             }

--- a/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
+++ b/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
@@ -62,9 +62,13 @@ Java_org_eclipse_jetty_setuid_SetUID_setgid (JNIEnv * env, jclass j, jint gid)
 }
 
 JNIEXPORT jint JNICALL 
-Java_org_eclipse_jetty_setuid_SetUID_cleargroups (JNIEnv * env, jclass j)
+Java_org_eclipse_jetty_setuid_SetUID_setgroups (JNIEnv * env, jclass j, jintArray groups)
 {
-    return((jint)setgroups(0, NULL));
+    jsize len = (*env)->GetArrayLength(env, groups);
+    jint *groupIds = (*env)->GetIntArrayElements(env, groups, 0);
+    jint retVal = ((jint)setgroups(len, (gid_t *)groupIds));
+    (*env)->ReleaseIntArrayElements(env, groups, groupIds, 0);
+    return retVal;
 }
 
 /* User informaton implementatons */

--- a/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
+++ b/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
@@ -58,7 +58,12 @@ Java_org_eclipse_jetty_setuid_SetUID_setumask (JNIEnv * env, jclass j, jint mask
 JNIEXPORT jint JNICALL 
 Java_org_eclipse_jetty_setuid_SetUID_setgid (JNIEnv * env, jclass j, jint gid)
 {
-    return((jint)setgid((gid_t)gid));
+    int result = setgroups(0, NULL);
+    if (result == 0)
+    {
+        result = setgid((gid_t)gid);
+    }
+    return(jint)result;
 }
 
 

--- a/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
+++ b/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
@@ -58,15 +58,14 @@ Java_org_eclipse_jetty_setuid_SetUID_setumask (JNIEnv * env, jclass j, jint mask
 JNIEXPORT jint JNICALL 
 Java_org_eclipse_jetty_setuid_SetUID_setgid (JNIEnv * env, jclass j, jint gid)
 {
-    int result = setgroups(0, NULL);
-    if (result == 0)
-    {
-        result = setgid((gid_t)gid);
-    }
-    return(jint)result;
+    return(jint)setgid((gid_t)gid);
 }
 
-
+JNIEXPORT jint JNICALL 
+Java_org_eclipse_jetty_setuid_SetUID_cleargroups (JNIEnv * env, jclass j)
+{
+    return(jint)setgroups(0, NULL);
+}
 
 /* User informaton implementatons */
 

--- a/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
+++ b/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.c
@@ -58,13 +58,13 @@ Java_org_eclipse_jetty_setuid_SetUID_setumask (JNIEnv * env, jclass j, jint mask
 JNIEXPORT jint JNICALL 
 Java_org_eclipse_jetty_setuid_SetUID_setgid (JNIEnv * env, jclass j, jint gid)
 {
-    return(jint)setgid((gid_t)gid);
+    return((jint)setgid((gid_t)gid));
 }
 
 JNIEXPORT jint JNICALL 
 Java_org_eclipse_jetty_setuid_SetUID_cleargroups (JNIEnv * env, jclass j)
 {
-    return(jint)setgroups(0, NULL);
+    return((jint)setgroups(0, NULL));
 }
 
 /* User informaton implementatons */

--- a/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.h
+++ b/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.h
@@ -37,6 +37,14 @@ JNIEXPORT jint JNICALL Java_org_eclipse_jetty_setuid_SetUID_setgid
 
 /*
  * Class:     org_eclipse_jetty_setuid_SetUID
+ * Method:    cleargroups
+ * Signature: (I)I
+ */
+JNIEXPORT jint JNICALL Java_org_eclipse_jetty_setuid_SetUID_cleargroups
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     org_eclipse_jetty_setuid_SetUID
  * Method:    getpwnam
  * Signature: (Ljava/lang/String;)Lorg/eclipse/jetty/setuid/Passwd;
  */

--- a/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.h
+++ b/jetty-setuid/jetty-setuid-native/src/main/resources/org_eclipse_jetty_setuid_SetUID.h
@@ -37,11 +37,11 @@ JNIEXPORT jint JNICALL Java_org_eclipse_jetty_setuid_SetUID_setgid
 
 /*
  * Class:     org_eclipse_jetty_setuid_SetUID
- * Method:    cleargroups
+ * Method:    setgroups
  * Signature: (I)I
  */
-JNIEXPORT jint JNICALL Java_org_eclipse_jetty_setuid_SetUID_cleargroups
-  (JNIEnv *, jclass);
+JNIEXPORT jint JNICALL Java_org_eclipse_jetty_setuid_SetUID_setgroups
+  (JNIEnv *, jclass, jintArray groups);
 
 /*
  * Class:     org_eclipse_jetty_setuid_SetUID

--- a/jetty-setuid/pom.xml
+++ b/jetty-setuid/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.eclipse.jetty.toolchain</groupId>
         <artifactId>jetty-toolchain</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7</version>
         <relativePath>../jetty-toolchain</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This should fix issue #6 by always calling setgroups(0, NULL) before a call to setgid.

I'm unsure whether you would, instead, prefer to expose the setgroups method to java and have it be responsible for calling it before it calls setgid - Happy to do that if it's preferred.

I'm also unsure how to effectively test this change (beyond what I'm doing manually locally and seeing that supplemental groups are now cleared in the case I was seeing them - Very open to trying to build some testing in if someone can outline what they'd like to see.

Also perhaps worth noting - I had to hack the osx and linux project's pom files and symlink some headers around the place to have the build actually work on each platform in my setup. I'm not sure if that's just a local issue for me or if it'll affect others who might try to build this change. Happy to share the changes I made it they'll be valuable to someone, but they're probably not 'principled' changes that ought to actually be committed.