### PR TITLE
Replace schemas and dtds with clean eplv2 versions from https://githu…

### DIFF
--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_0.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
@@ -10,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)jsp_2_0.xsds	1.17 03/18/03
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_1.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
@@ -10,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)jsp_2_1.xsds	1.5 08/11/05
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_2.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_2.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
@@ -10,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)jsp_2_2.xsds	02/26/09
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_3.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/jsp_2_3.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,49 +24,6 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="2.3">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd
@@ -1,38 +1,18 @@
 <!--
 
-DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+    Copyright (c) 2000, 2018 Oracle and/or its affiliates. All rights reserved.
 
-Copyright 2000-2007 Sun Microsystems, Inc. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-The contents of this file are subject to the terms of either the GNU
-General Public License Version 2 only ("GPL") or the Common Development
-and Distribution License("CDDL") (collectively, the "License").  You
-may not use this file except in compliance with the License. You can obtain
-a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
-or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
-language governing permissions and limitations under the License.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-When distributing the software, include this License Header Notice in each
-file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
-Sun designates this particular file as subject to the "Classpath" exception
-as provided by Sun in the GPL Version 2 section of the License file that
-accompanied this code.  If applicable, add the following below the License
-Header, with the fields enclosed by brackets [] replaced by your own
-identifying information: "Portions Copyrighted [year]
-[name of copyright owner]"
-
-Contributor(s):
-
-If you wish your version of this file to be governed by only the CDDL or
-only the GPL Version 2, indicate your decision by adding "[Contributor]
-elects to include this software in this distribution under the [CDDL or GPL
-Version 2] license."  If you don't indicate a single choice of license, a
-recipient has the option to distribute your version of this file under
-either the CDDL, the GPL Version 2 or to extend the choice of license to
-its licensees as provided above.  However, if you add GPL Version 2 code
-and therefore, elected the GPL Version 2 license, then the option applies
-only if the new code is made subject to such option by the copyright
-holder.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd
@@ -1,38 +1,18 @@
 <!--
 
-DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+    Copyright (c) 2000, 2018 Oracle and/or its affiliates. All rights reserved.
 
-Copyright 2000-2007 Sun Microsystems, Inc. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-The contents of this file are subject to the terms of either the GNU
-General Public License Version 2 only ("GPL") or the Common Development
-and Distribution License("CDDL") (collectively, the "License").  You
-may not use this file except in compliance with the License. You can obtain
-a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
-or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
-language governing permissions and limitations under the License.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-When distributing the software, include this License Header Notice in each
-file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
-Sun designates this particular file as subject to the "Classpath" exception
-as provided by Sun in the GPL Version 2 section of the License file that
-accompanied this code.  If applicable, add the following below the License
-Header, with the fields enclosed by brackets [] replaced by your own
-identifying information: "Portions Copyrighted [year]
-[name of copyright owner]"
-
-Contributor(s):
-
-If you wish your version of this file to be governed by only the CDDL or
-only the GPL Version 2, indicate your decision by adding "[Contributor]
-elects to include this software in this distribution under the [CDDL or GPL
-Version 2] license."  If you don't indicate a single choice of license, a
-recipient has the option to distribute your version of this file under
-either the CDDL, the GPL Version 2 or to extend the choice of license to
-its licensees as provided above.  However, if you add GPL Version 2 code
-and therefore, elected the GPL Version 2 license, then the option applies
-only if the new code is made subject to such option by the copyright
-holder.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema
      targetNamespace="http://java.sun.com/xml/ns/j2ee"
      xmlns:j2ee="http://java.sun.com/xml/ns/j2ee"
@@ -13,51 +31,7 @@
     </xsd:documentation>
   </xsd:annotation>
 
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
-
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-
-      Contributor(s):
-
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
+<xsd:annotation>
     <xsd:documentation>
       <![CDATA[
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_2_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/jsp/resources/web-jsptaglibrary_2_1.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema
      targetNamespace="http://java.sun.com/xml/ns/javaee"
      xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -10,50 +28,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)web-jsptaglibrary_2_1.xsds	1.1
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
-
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-
-      Contributor(s):
-
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/j2ee_1_4.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/j2ee_1_4.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema
      targetNamespace="http://java.sun.com/xml/ns/j2ee"
@@ -10,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)j2ee_1_4.xsds	1.43 03/09/16
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-      
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/j2ee_web_services_1_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/j2ee_web_services_1_1.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
@@ -10,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)j2ee_web_services_1_1.xsds	1.11 02/11/03
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-      
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/j2ee_web_services_client_1_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/j2ee_web_services_client_1_1.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
@@ -11,51 +28,6 @@
     <xsd:documentation>
       @(#)j2ee_web_services_client_1_1.xsds	1.10 02/11/03
     </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-      
-    </xsd:documentation>
-
   </xsd:annotation>
 
   <xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_5.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_5.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema
      targetNamespace="http://java.sun.com/xml/ns/javaee"
@@ -10,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)javaee_5.xsds	1.65 06/02/17
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2005 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-      
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_6.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_6.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema targetNamespace="http://java.sun.com/xml/ns/javaee"
             xmlns:javaee="http://java.sun.com/xml/ns/javaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -8,51 +26,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-      $Id: javaee_6.xsd,v 1.1.2.1 2011/03/23 09:21:12 hmalphett Exp $
-      
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
+      $Id$
       
     </xsd:documentation>
   </xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_7.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_7.xsd
@@ -1,53 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="7">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
@@ -527,7 +502,7 @@
                    minOccurs="0">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             A JDBC URL. If the <code>url</code> property is specified
             along with other standard <code>DataSource</code> properties
             such as <code>serverName</code>, <code>databaseName</code>
@@ -723,7 +698,7 @@
   <xsd:complexType name="display-nameType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The display-name type contains a short name that is intended
         to be displayed by tools. It is used by display-name
         elements.  The display name need not be unique.
@@ -753,7 +728,7 @@
   <xsd:complexType name="ejb-linkType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The ejb-linkType is used by ejb-link
         elements in the ejb-ref or ejb-local-ref elements to specify
         that an EJB reference is linked to enterprise bean.
@@ -845,7 +820,7 @@
   <xsd:complexType name="ejb-ref-nameType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The ejb-ref-name element contains the name of an EJB
         reference. The EJB reference is an entry in the
         Deployment Component's environment and is relative to the
@@ -1001,7 +976,7 @@
                    type="javaee:jndi-nameType">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The env-entry-name element contains the name of a
             Deployment Component's environment entry.  The name
             is a JNDI name relative to the java:comp/env
@@ -1023,7 +998,7 @@
                    minOccurs="0">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The env-entry-type element contains the Java language
             type of the environment entry.  If an injection target
             is specified for the environment entry, the type may
@@ -1044,7 +1019,7 @@
                    minOccurs="0">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The env-entry-value designates the value of a
             Deployment Component's environment entry. The value
             must be a String that is valid for the
@@ -1072,7 +1047,7 @@
   <xsd:complexType name="env-entry-type-valuesType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         This type contains the fully-qualified Java type of the
         environment entry value that is expected by the
         application's code.
@@ -1173,7 +1148,7 @@
                    minOccurs="0">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The small-icon element contains the name of a file
             containing a small (16 x 16) icon image. The file
             name is a relative path within the Deployment
@@ -1195,7 +1170,7 @@
                    minOccurs="0">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The large-icon element contains the name of a file
             containing a large
             (32 x 32) icon image. The file name is a relative 
@@ -1321,7 +1296,7 @@
   <xsd:complexType name="jdbc-urlType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The jdbc-urlType contains the url pattern of the mapping.
         It must follow the rules specified in Section 9.3 of the
         JDBC Specification where the format is:
@@ -1630,7 +1605,7 @@
   <xsd:complexType name="homeType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The homeType defines the fully-qualified name of
         an enterprise bean's home interface. 
         
@@ -1957,7 +1932,7 @@
   <xsd:complexType name="persistence-context-refType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The persistence-context-ref element contains a declaration
         of Deployment Component's reference to a persistence context
         associated within a Deployment Component's
@@ -2146,7 +2121,7 @@
   <xsd:complexType name="persistence-unit-refType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The persistence-unit-ref element contains a declaration
         of Deployment Component's reference to a persistence unit
         associated within a Deployment Component's
@@ -2228,7 +2203,7 @@
   <xsd:complexType name="remoteType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The remote element contains the fully-qualified name
         of the enterprise bean's remote interface.
         
@@ -2250,7 +2225,7 @@
   <xsd:complexType name="resource-env-refType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The resource-env-refType is used to define
         resource-env-ref elements.  It contains a declaration of a
         Deployment Component's reference to an administered object
@@ -2327,7 +2302,7 @@
   <xsd:complexType name="resource-refType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The resource-refType contains a declaration of a
         Deployment Component's reference to an external resource. It
         consists of an optional description, the resource manager
@@ -2509,7 +2484,7 @@
   <xsd:complexType name="security-roleType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The security-roleType contains the definition of a security
         role. The definition consists of an optional description of
         the security role, and the security role name.
@@ -2818,7 +2793,7 @@
   <xsd:complexType name="message-destinationType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The message-destinationType specifies a message
         destination. The logical destination described by this
         element is mapped to a physical destination by the Deployer.
@@ -2907,7 +2882,7 @@
   <xsd:complexType name="message-destination-refType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The message-destination-ref element contains a declaration
         of Deployment Component's reference to a message destination
         associated with a resource in Deployment Component's
@@ -3015,7 +2990,7 @@
   <xsd:complexType name="message-destination-typeType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The message-destination-typeType specifies the type of
         the destination. The type is specified by the Java interface
         expected to be implemented by the destination.

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_8.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_8.xsd
@@ -1,53 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="8">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2017 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_1_2.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_1_2.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
 	    xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)javaee_web_services_1_2.xsds	1.18 02/13/06
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2005 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-      
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_1_3.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_1_3.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://java.sun.com/xml/ns/javaee"
             xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,51 +27,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-      $Id: javaee_web_services_1_3.xsd,v 1.1.2.1 2011/03/23 09:21:12 hmalphett Exp $
-      
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
+      $Id$
       
     </xsd:documentation>
   </xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_1_4.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_1_4.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,49 +24,6 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.4">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
@@ -60,7 +35,7 @@
 
   <xsd:annotation>
     <xsd:documentation>
-      <![CDATA[[
+      <![CDATA[
       The webservices element is the root element for the web services
       deployment descriptor.  It specifies the set of web service
       descriptions that are to be deployed into the Java EE Application
@@ -183,7 +158,7 @@
                    type="javaee:string">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The port-component-name element specifies a port component's
             name.  This name is assigned by the module producer to name
             the service implementation bean in the module's deployment
@@ -314,7 +289,7 @@
                    maxOccurs="1">
         <xsd:annotation>
           <xsd:documentation>
-            <![CDATA[[
+            <![CDATA[
             The service-endpoint-interface element contains the
             fully-qualified name of the port component's Service Endpoint
             Interface.
@@ -400,7 +375,7 @@
   <xsd:complexType name="servlet-linkType">
     <xsd:annotation>
       <xsd:documentation>
-        <![CDATA[[
+        <![CDATA[
         The servlet-link element is used in the service-impl-bean element
         to specify that a Service Implementation Bean is defined as a
         JAX-RPC Service Endpoint.
@@ -530,7 +505,7 @@
         <xsd:key name="port-component-name-key">
           <xsd:annotation>
             <xsd:documentation>
-              <![CDATA[[
+              <![CDATA[
               	The port-component-name element specifies a port
               	component's name.  This name is assigned by the module
               	producer to name the service implementation bean in the

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_client_1_2.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_client_1_2.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
 	    xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)javaee_web_services_client_1_2.xsds	1.19 02/13/06
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
-
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-
-      Contributor(s):
-
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_client_1_3.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_client_1_3.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://java.sun.com/xml/ns/javaee"
             xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,51 +27,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-      $Id: javaee_web_services_client_1_3.xsd,v 1.1.2.1 2011/03/23 09:21:13 hmalphett Exp $
-      
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
+      $Id$
       
     </xsd:documentation>
   </xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_client_1_4.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/javaee_web_services_client_1_4.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,49 +24,6 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.4">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/permissions_7.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/permissions_7.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,53 +24,10 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="7">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
-      <![CDATA[[
+      <![CDATA[
       This is the XML Schema for the application or module declared permissions 7.
       The declared permissions file must be named "META-INF/permissions.xml" in the
       application's ear file, or in a module's META-INF/permissions.xml if

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_2.dtd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_2.dtd
@@ -1,38 +1,18 @@
 <!--
 
-DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+    Copyright (c) 1999, 2018 Oracle and/or its affiliates. All rights reserved.
 
-Copyright 1999 Sun Microsystems, Inc. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-The contents of this file are subject to the terms of either the GNU
-General Public License Version 2 only ("GPL") or the Common Development
-and Distribution License("CDDL") (collectively, the "License").  You
-may not use this file except in compliance with the License. You can obtain
-a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
-or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
-language governing permissions and limitations under the License.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-When distributing the software, include this License Header Notice in each
-file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
-Sun designates this particular file as subject to the "Classpath" exception
-as provided by Sun in the GPL Version 2 section of the License file that
-accompanied this code.  If applicable, add the following below the License
-Header, with the fields enclosed by brackets [] replaced by your own
-identifying information: "Portions Copyrighted [year]
-[name of copyright owner]"
-
-Contributor(s):
-
-If you wish your version of this file to be governed by only the CDDL or
-only the GPL Version 2, indicate your decision by adding "[Contributor]
-elects to include this software in this distribution under the [CDDL or GPL
-Version 2] license."  If you don't indicate a single choice of license, a
-recipient has the option to distribute your version of this file under
-either the CDDL, the GPL Version 2 or to extend the choice of license to
-its licensees as provided above.  However, if you add GPL Version 2 code
-and therefore, elected the GPL Version 2 license, then the option applies
-only if the new code is made subject to such option by the copyright
-holder.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_3.dtd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_3.dtd
@@ -1,38 +1,18 @@
 <!--
 
-DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+    Copyright (c) 2000, 2018 Oracle and/or its affiliates. All rights reserved.
 
-Copyright 2000 Sun Microsystems, Inc. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-The contents of this file are subject to the terms of either the GNU
-General Public License Version 2 only ("GPL") or the Common Development
-and Distribution License("CDDL") (collectively, the "License").  You
-may not use this file except in compliance with the License. You can obtain
-a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
-or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
-language governing permissions and limitations under the License.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-When distributing the software, include this License Header Notice in each
-file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
-Sun designates this particular file as subject to the "Classpath" exception
-as provided by Sun in the GPL Version 2 section of the License file that
-accompanied this code.  If applicable, add the following below the License
-Header, with the fields enclosed by brackets [] replaced by your own
-identifying information: "Portions Copyrighted [year]
-[name of copyright owner]"
-
-Contributor(s):
-
-If you wish your version of this file to be governed by only the CDDL or
-only the GPL Version 2, indicate your decision by adding "[Contributor]
-elects to include this software in this distribution under the [CDDL or GPL
-Version 2] license."  If you don't indicate a single choice of license, a
-recipient has the option to distribute your version of this file under
-either the CDDL, the GPL Version 2 or to extend the choice of license to
-its licensees as provided above.  However, if you add GPL Version 2 code
-and therefore, elected the GPL Version 2 license, then the option applies
-only if the new code is made subject to such option by the copyright
-holder.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_4.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_4.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
@@ -9,51 +26,7 @@
 	    version="2.4">
   <xsd:annotation>
     <xsd:documentation>
-      @(#)web-app_2_4.xsds	1.60 03/08/26
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2004-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
+      @(#)web-app_2_4.xsds	1.61 04/04/16
     </xsd:documentation>
   </xsd:annotation>
 
@@ -799,7 +772,7 @@
 
     <xsd:simpleContent>
       <xsd:restriction base="j2ee:string">
-        <xsd:pattern value="[^\p{Cc}^\s]+/[^\p{Cc}^\s]+"/>
+	<xsd:pattern value="[^\p{Cc}^\s]+/[^\p{Cc}^\s]+"/>
       </xsd:restriction>
     </xsd:simpleContent>
   </xsd:complexType>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_5.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_2_5.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
@@ -9,51 +26,7 @@
 	    version="2.5">
   <xsd:annotation>
     <xsd:documentation>
-      @(#)web-app_2_5.xsds	1.62 05/08/06
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
+      @(#)web-app_2_5.xsds	1.68 07/03/09
     </xsd:documentation>
   </xsd:annotation>
 
@@ -637,7 +610,7 @@
     </xsd:annotation>
 
      <xsd:restriction base="xsd:token">
-         <xsd:pattern value="[&#33;-&#126;-[\(\)&#60;&#62;@,;:&#34;/\[\]?=\{\}\\\p{Z}]]+"/>
+      <xsd:pattern value="[&#33;-&#126;-[\(\)&#60;&#62;@,;:&#34;/\[\]?=\{\}\\\p{Z}]]+"/>
      </xsd:restriction>
 
   </xsd:simpleType>
@@ -891,8 +864,6 @@
 	The servlet-name element contains the canonical name of the
 	servlet. Each servlet name is unique within the web
 	application.
-        The special servlet name of "*" may be used to reference all
-        servlets.
 
       </xsd:documentation>
     </xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_3_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_3_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://java.sun.com/xml/ns/javaee"
             xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,51 +27,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-      $Id: web-app_3_0.xsd,v 1.1.2.1 2011/03/23 09:21:12 hmalphett Exp $
-      
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
+      $Id$
       
     </xsd:documentation>
   </xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_3_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_3_1.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,53 +24,10 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="3.1">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
-      <![CDATA[[
+      <![CDATA[
       This is the XML Schema for the Servlet 3.1 deployment descriptor.
       The deployment descriptor must be named "WEB-INF/web.xml" in the
       web application's war file.  All Servlet deployment descriptors

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_4_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-app_4_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,49 +24,6 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="4.0">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2017 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-common_3_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-common_3_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://java.sun.com/xml/ns/javaee"
             xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,51 +27,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-      $Id: web-common_3_0.xsd,v 1.1.2.1 2011/03/23 09:21:13 hmalphett Exp $
-      
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
+      $Id$
       
     </xsd:documentation>
   </xsd:annotation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-common_3_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-common_3_1.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,53 +24,10 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="3.1">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
-      <![CDATA[[
+      <![CDATA[
       This is the common XML Schema for the Servlet 3.1 deployment descriptor.
       This file is in turn used by web.xml and web-fragment.xml
       web application's war file.  All Servlet deployment descriptors

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-common_4_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-common_4_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,49 +24,6 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="4.0">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2017 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-fragment_3_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-fragment_3_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
 	    xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)web-fragment_3_0.xsds
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
-
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-
-      Contributor(s):
-
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-fragment_3_1.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-fragment_3_1.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,53 +24,10 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="3.1">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
-      <![CDATA[[
+      <![CDATA[
       This is the XML Schema for the Servlet 3.1 deployment descriptor.
       The deployment descriptor must be named "META-INF/web-fragment.xml"
       in the web fragment's jar file.  All Servlet deployment descriptors

--- a/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-fragment_4_0.xsd
+++ b/jetty-schemas/src/main/resources/jakarta/servlet/resources/web-fragment_4_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
             xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
@@ -6,49 +24,6 @@
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="4.0">
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright (c) 2009-2017 Oracle and/or its affiliates. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the GNU
-      General Public License Version 2 only ("GPL") or the Common Development
-      and Distribution License("CDDL") (collectively, the "License").  You
-      may not use this file except in compliance with the License.  You can
-      obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-      or packager/legal/LICENSE.txt.  See the License for the specific
-      language governing permissions and limitations under the License.
-      
-      When distributing the software, include this License Header Notice in each
-      file and include the License file at packager/legal/LICENSE.txt.
-      
-      GPL Classpath Exception:
-      Oracle designates this particular file as subject to the "Classpath"
-      exception as provided by Oracle in the GPL Version 2 section of the License
-      file that accompanied this code.
-      
-      Modifications:
-      If applicable, add the following below the License Header, with the fields
-      enclosed by brackets [] replaced by your own identifying information:
-      "Portions Copyright [year] [name of copyright owner]"
-      
-      Contributor(s):
-      If you wish your version of this file to be governed by only the CDDL or
-      only the GPL Version 2, indicate your decision by adding "[Contributor]
-      elects to include this software in this distribution under the [CDDL or GPL
-      Version 2] license."  If you don't indicate a single choice of license, a
-      recipient has the option to distribute your version of this file under
-      either the CDDL, the GPL Version 2 or to extend the choice of license to
-      its licensees as provided above.  However, if you add GPL Version 2 code
-      and therefore, elected the GPL Version 2 license, then the option applies
-      only if the new code is made subject to such option by the copyright
-      holder.
-      
-    </xsd:documentation>
-  </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>


### PR DESCRIPTION
Replace schemas and dtds with clean eplv2 versions from https://github.com/eclipse-ee4j/glassfish

Signed-off-by: gregw <gregw@webtide.com>