### PR TITLE
Cleaning up resource refernces in jetty-jakarta-servlet-api

### DIFF
--- a/jetty-jakarta-servlet-api/pom.xml
+++ b/jetty-jakarta-servlet-api/pom.xml
@@ -23,11 +23,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <version>5.0.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty.toolchain</groupId>
-      <artifactId>jetty-schemas</artifactId>
-      <version>5.2</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -120,7 +115,6 @@
             <Export-Package>
               jakarta.servlet;uses:="jakarta.servlet.annotation,jakarta.servlet.descriptor";version="5.0.0",
               jakarta.servlet.resources;version="5.0.0",
-              jakarta.servlet.jsp.resources;version="5.0.0",
               jakarta.servlet.annotation;uses:="jakarta.servlet";version="5.0.0",
               jakarta.servlet.http;uses:="jakarta.servlet";version="5.0.0",
               jakarta.servlet.descriptor;version="5.0.0"
@@ -156,13 +150,19 @@
                   <artifact>jakarta.servlet:jakarta.servlet-api</artifact>
                   <includes>
                     <include>jakarta/**/*.properties</include>
+                    <include>jakarta/**/*.xsd</include>
+                    <include>jakarta/**/*.dtd</include>
                     <include>jakarta/**/package.html</include>
                   </includes>
+                  <excludes>
+                    <exclude>jakarta/servlet/jsp/**</exclude>
+                    <exclude>META-INF/**</exclude>
+                    <exclude>about.html</exclude>
+                  </excludes>
                 </filter>
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>jakarta/servlet/jsp/**</exclude>
                     <exclude>META-INF/**</exclude>
                     <exclude>about.html</exclude>
                   </excludes>


### PR DESCRIPTION
Cleanup the creation of the jetty-jakarta-servlet-api jar with a focus on cleaning up the resources that are included.

We no longer need to rely on jetty-schemas, as the official jakarta.servlet.api jar has the schemas already present.

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>