### PR TITLE
Fix WorkDirExtension on windows.

### DIFF
--- a/jetty-test-helper/src/main/java/org/eclipse/jetty/toolchain/test/URLEncode.java
+++ b/jetty-test-helper/src/main/java/org/eclipse/jetty/toolchain/test/URLEncode.java
@@ -1,0 +1,30 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.toolchain.test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+public class URLEncode
+{
+    public static String encode(String value, String charset) throws UnsupportedEncodingException
+    {
+        return URLEncoder.encode(value, charset).replaceAll("\\*", "%2A");
+    }
+}

--- a/jetty-test-helper/src/main/java/org/eclipse/jetty/toolchain/test/jupiter/WorkDirExtension.java
+++ b/jetty-test-helper/src/main/java/org/eclipse/jetty/toolchain/test/jupiter/WorkDirExtension.java
@@ -20,6 +20,7 @@ package org.eclipse.jetty.toolchain.test.jupiter;
 
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.StringMangler;
+import org.eclipse.jetty.toolchain.test.URLEncode;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.util.ExceptionUtils;
@@ -28,7 +29,6 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
@@ -107,38 +107,35 @@ public class WorkDirExtension implements BeforeAllCallback, BeforeEachCallback, 
 
     private Path toPath(Class<?> classContext, ExtensionContext context) throws IOException
     {
-        StringBuilder dirNameBuilder = new StringBuilder();
+        StringBuilder dirName = new StringBuilder();
 
         Class<?> clazz = context.getTestClass().orElse(classContext);
-        dirNameBuilder.append(StringMangler.condensePackageString(clazz.getName()));
-        dirNameBuilder.append(File.separatorChar);
+        dirName.append(StringMangler.condensePackageString(clazz.getName()));
+        dirName.append(File.separatorChar);
 
         if (context.getTestMethod().isPresent())
         {
             String methodname = context.getTestMethod().get().getName();
             if (OS.WINDOWS.isCurrentOs())
             {
-                dirNameBuilder.append(StringMangler.maxStringLength(30, methodname));
+                dirName.append(StringMangler.maxStringLength(30, methodname));
             }
             else
             {
-                dirNameBuilder.append(methodname);
+                dirName.append(methodname);
             }
 
             if (!context.getDisplayName().startsWith(methodname))
             {
-                dirNameBuilder.append(URLEncoder.encode(context.getDisplayName().trim(), UTF_8.toString()));
+                dirName.append(URLEncode.encode(context.getDisplayName().trim(), UTF_8.toString()));
             }
         }
         else
         {
-            dirNameBuilder.append(URLEncoder.encode(context.getDisplayName().trim(), UTF_8.toString()));
+            dirName.append(URLEncode.encode(context.getDisplayName().trim(), UTF_8.toString()));
         }
 
-        String dirName = OS.WINDOWS.isCurrentOs() ?
-                dirNameBuilder.toString().replaceAll("[^a-zA-Z0-9-]", "_") :
-                dirNameBuilder.toString();
-        return MavenTestingUtils.getTargetTestingPath().resolve(dirName);
+        return MavenTestingUtils.getTargetTestingPath().resolve(dirName.toString());
     }
 
     @Override

--- a/jetty-test-helper/src/test/java/org/eclipse/jetty/toolchain/test/UrlEncodeTest.java
+++ b/jetty-test-helper/src/test/java/org/eclipse/jetty/toolchain/test/UrlEncodeTest.java
@@ -1,0 +1,58 @@
+//
+//  ========================================================================
+//  Copyright (c) 1995-2020 Mort Bay Consulting Pty. Ltd.
+//  ------------------------------------------------------------------------
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the Eclipse Public License v1.0
+//  and Apache License v2.0 which accompanies this distribution.
+//
+//      The Eclipse Public License is available at
+//      http://www.eclipse.org/legal/epl-v10.html
+//
+//      The Apache License v2.0 is available at
+//      http://www.opensource.org/licenses/apache2.0.php
+//
+//  You may elect to redistribute this code under either of these licenses.
+//  ========================================================================
+//
+
+package org.eclipse.jetty.toolchain.test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class UrlEncodeTest
+{
+    public static Stream<Arguments> getArguments()
+    {
+        return Stream.of(
+                Arguments.of("", ""),
+                Arguments.of("<", "%3C"),
+                Arguments.of(">", "%3E"),
+                Arguments.of(":", "%3A"),
+                Arguments.of("\"", "%22"),
+                Arguments.of("/", "%2F"),
+                Arguments.of("\\", "%5C"),
+                Arguments.of("|", "%7C"),
+                Arguments.of("?", "%3F"),
+                Arguments.of("*", "%2A"),
+                Arguments.of("\000", "%00"),
+                Arguments.of("\032", "%1A"),
+                Arguments.of("\177", "%7F")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getArguments")
+    public void test(String value, String expected) throws Exception
+    {
+        assertThat(URLEncode.encode(value, StandardCharsets.UTF_8.name()), is(expected));
+    }
+}

--- a/jetty-test-helper/src/test/java/org/eclipse/jetty/toolchain/test/jupiter/WorkDirExtensionTest.java
+++ b/jetty-test-helper/src/test/java/org/eclipse/jetty/toolchain/test/jupiter/WorkDirExtensionTest.java
@@ -18,6 +18,8 @@
 
 package org.eclipse.jetty.toolchain.test.jupiter;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing Junit Jupiter behavior with {@link WorkDir} and {@link WorkDirExtension}
@@ -88,16 +91,17 @@ public class WorkDirExtensionTest
         fieldDir.getPath();
     }
 
+    // Leave this declared as List<Object[]> as this triggers a different codepath in junit5
     private static List<Object[]> objValues()
     {
         List<Object[]> ret = new ArrayList<>();
 
-        HashMap<String,Object> map1 = new HashMap<>();
-        ret.add(new Object[] { "{}",  map1});
+        HashMap<String, Object> map1 = new HashMap<>();
+        ret.add(new Object[]{"{}", map1});
 
-        HashMap<String,Object> map2 = new HashMap<>();
+        HashMap<String, Object> map2 = new HashMap<>();
         map2.put("a", "foo");
-        ret.add(new Object[] { "{'a': 'foo'}", map2 });
+        ret.add(new Object[]{"{'a': 'foo'}", map2});
 
         return ret;
     }
@@ -108,6 +112,25 @@ public class WorkDirExtensionTest
     {
         assertNotNull(obj1);
         assertNotNull(obj2);
+    }
+
+    private static Stream<Arguments> wholeCharSpace()
+    {
+        List<Arguments> cases = new ArrayList<>();
+        for (int i = 0; i < 128; i++)
+        {
+            cases.add(Arguments.of("dir-" + (char)i));
+        }
+        return cases.stream();
+    }
+
+    @ParameterizedTest(name="[{index}] {arguments}")
+    @MethodSource("wholeCharSpace")
+    public void testWorkDir_WholeCharspace(String path)
+    {
+        Path dir = fieldDir.getEmptyPathDir();
+        assertTrue(Files.exists(dir), "Does [" + path + "] exist: " + dir);
+        assertTrue(Files.isDirectory(dir), "Is [" + path + "] a directory: " + dir);
     }
 }
 


### PR DESCRIPTION
https://github.com/eclipse/jetty.project/issues/6100

Windows is not liking filePaths containing certain characters like `*`. 
I have changed `WorkDirExtension` to be more restrictive about which characters it allows in the directory name on windows.

When I run the jetty.project tests on windows locally I was getting many failures, this change seems to fix 90% of the failures I was getting.