### PR TITLE
Updating SPDX-License-Identifier to align with Servlet Spec/API

### DIFF
--- a/jetty-javax-servlet-api/src/main/resources/META-INF/LICENSE.md
+++ b/jetty-javax-servlet-api/src/main/resources/META-INF/LICENSE.md
@@ -841,3 +841,5 @@ http://www.eclipse.org/legal/epl-2.0, or the Apache Software License
     exception to your version of the library, but you are not obligated to
     do so.  If you do not wish to do so, delete this exception statement
     from your version.
+
+SPDX-License-Identifier: (EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0

--- a/jetty-javax-servlet-api/src/main/resources/META-INF/NOTICE.md
+++ b/jetty-javax-servlet-api/src/main/resources/META-INF/NOTICE.md
@@ -21,14 +21,15 @@ source code repository logs.
 ## Declared Project Licenses
 
 This program and the accompanying materials are made available under the terms
-of the Eclipse Public License v. 2.0 which is available at
+of the Apache License v. 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0
+and the Eclipse Public License v. 2.0 which is available at
 http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
 available under the following Secondary Licenses when the conditions for such
 availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
 General Public License, version 2 with the GNU Classpath Exception which is
 available at https://www.gnu.org/software/classpath/license.html.
 
-SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+SPDX-License-Identifier: (EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0
 
 
 ## Source Code


### PR DESCRIPTION
See https://github.com/eclipse-ee4j/servlet-api/issues/347#issuecomment-686566030

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>