### PR TITLE
Fix umask syscall

### DIFF
--- a/jetty-setuid/src/main/java/org/eclipse/jetty/setuid/LibC.java
+++ b/jetty-setuid/src/main/java/org/eclipse/jetty/setuid/LibC.java
@@ -25,7 +25,7 @@ public interface LibC extends Library
 {
     LibC INSTANCE = Native.load("c", LibC.class);
 
-    int setumask(int mask);
+    int umask(int mask);
 
     int setuid(int uid);
 

--- a/jetty-setuid/src/main/java/org/eclipse/jetty/setuid/SetUIDListener.java
+++ b/jetty-setuid/src/main/java/org/eclipse/jetty/setuid/SetUIDListener.java
@@ -171,7 +171,7 @@ public class SetUIDListener implements LifeCycle.Listener
         if (_umask > -1)
         {
             LOG.info("Setting umask=0{}", Integer.toString(_umask,8));
-            LibC.INSTANCE.setumask(_umask);
+            LibC.INSTANCE.umask(_umask);
         }
 
         if (_rlimitNoFiles != null)

--- a/jetty-setuid/src/test/java/org/eclipse/jetty/setuid/TestLibC.java
+++ b/jetty-setuid/src/test/java/org/eclipse/jetty/setuid/TestLibC.java
@@ -13,10 +13,16 @@
 
 package org.eclipse.jetty.setuid;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLibC
 {
@@ -25,6 +31,11 @@ public class TestLibC
     {
         assertNull(LibC.INSTANCE.getpwnam("TheQuickBrownFoxJumpsOverToTheLazyDog"));
         assertNull(LibC.INSTANCE.getpwuid(-9999));
+
+        LibC.INSTANCE.umask(0777);
+        Path path = Files.createTempFile(getClass().getSimpleName(), ".tmp");
+        Set<PosixFilePermission> posixFilePermissions = Files.getPosixFilePermissions(path);
+        assertTrue(posixFilePermissions.isEmpty());
 
         // get the passwd info of root
         Passwd passwd1 = LibC.INSTANCE.getpwnam("root");


### PR DESCRIPTION
Change incorrect `setumask` sycall name to `umask`.

Closes #288 